### PR TITLE
insert-number.c: fixed out-of-bounds write

### DIFF
--- a/insert-number.c
+++ b/insert-number.c
@@ -98,7 +98,9 @@ void insert_linenum(char **argv, int first, int len, int space) {
         while (fgets(str, SIZE, rf) != NULL) {
             if (count == bound) {
                 bound *= 10;
-                space_str[strlen(space_str) - 1] = '\0';
+                if (strlen(space_str) > 0) {
+                    space_str[strlen(space_str) - 1] = '\0';
+                }
             }
             fprintf(wf, "%s%d  %s", space_str, count, str);
             count++;


### PR DESCRIPTION
- `strlen(space_str) == 0` の時に範囲外書き込みを行うバグの修正