### PR TITLE
insert-number.c : Support multiple dot file

### DIFF
--- a/insert-number.c
+++ b/insert-number.c
@@ -14,12 +14,13 @@ void argment_error() {
 char *new_filename(const char *name, int rem) {
     char *new = malloc(FILENAME_SIZE * sizeof(char));
     strcpy(new, name);
+    int ext_idx = strlen(new);
     for (int i = 0; i < strlen(new); i++) {
         if (new[i] == '.') {
-            new[i] = '\0';
-            break;
+            ext_idx = i;
         }
     }
+    new[ext_idx] = '\0';
     if (rem == 0)
         strcat(new, "-linenum.txt");
     else


### PR DESCRIPTION
`new_filename`内で新しいファイル名を作る際、元ファイルの一番最初のドットを終端文字に変換してしまう。

- `example.c`
- `example.hoge.c`
上の2つのファイルにinuを適用すると出力されるファイル名は共に`example-linenum.txt`のようになる。

これを
- `example-linenum.txt`
- `example.hoge-linenum.txt`
となるように変更した。